### PR TITLE
Update Top page for PyCon JP 2018, 2019

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -24,7 +24,10 @@ PyCon JPに関する最新情報は以下のBlog, Twitter, Facebookを参照し�
 PyCon JP 2019
 =============
 
-下記開催概要は現在の予定です。 詳細については決定し次第、上記Blog等で逐次お知らせします。
+下記開催概要は現在の予定です。 
+スプリントおよびチュートリアルについては開催場所、日程含め今後検討していきます。
+CFP開始、スポンサー募集時期についても今後となります。
+詳細については決定し次第、上記Blog等で逐次お知らせします。
 
 Here is a summary of the event details. We’ll post updates as further details are confirmed.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -19,6 +19,27 @@ PyCon JPに関する最新情報は以下のBlog, Twitter, Facebookを参照し�
 :Blog: `PyCon JP Blog <http://pyconjp.blogspot.jp/>`_
 :Twitter: `@PyConJ <https://twitter.com/pyconj>`_
 :Facebook: `PyConJP <http://www.facebook.com/PyConJP>`_
+
+
+PyCon JP 2019
+=============
+
+下記開催概要は現在の予定です。 詳細については決定し次第、上記Blog等で逐次お知らせします。
+
+Here is a summary of the event details. We’ll post updates as further details are confirmed.
+
+.. list-table::
+   :widths: 30 70
+   :stub-columns: 1
+
+   * - Development Sprints
+     - It is under consideration / 検討中
+   * - Tutorial
+     - It is under consideration / 検討中
+   * - Conference(2 days)
+     - 2019-9-16(Mon, public holiday), 2019-9-17(Tue)
+   * - Conference Venue / 会場
+     - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_
           
 PyCon JP 2018
 =============
@@ -26,7 +47,7 @@ PyCon JP 2018
 .. image:: /_static/pyconjp2018-logo.png
    :alt: PyCon JP 2018 logo
 
-下記は開催概要です。 詳細については　`公式Webサイト <https://pycon.jp/2018>`_ を確認ください。
+開催終了しました。下記は開催概要です。 詳細については　`公式Webサイト <https://pycon.jp/2018>`_ を確認ください。
 
 Here is a summary of the event details. You can see `Event Web site <https://pycon.jp/2018>`_ .
 
@@ -35,29 +56,20 @@ Here is a summary of the event details. You can see `Event Web site <https://pyc
    :stub-columns: 1
 
    * - Development Sprints
-     - (Planned)2018-9-15(Sat)
+     - 2018-9-15(Sat)
    * - Tutorial
-     - (Planned)2018-9-16(Sun)
+     - 2018-9-16(Sun)
    * - Conference(2 days)
      - 2018-9-17(Mon, public holiday), 2018-9-18(Tue)
    * - Conference Venue / 会場
      - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_
-   * - Participants / 参加者数
-     - (Planned)1000
    * - Organizers / 運営
      - PyCon JP 2018 Organizing Committee
-   * -
-       | Sponsor Contact 
-       | スポンサー問い合わせ先
-     - 
-       | sponsor@pycon.jp  
-       | We need a few days to a week to reply.
-       | 返信は数日から1週間目処です。
-   * - Contact / 問い合わせ先
-     - pyconjp@pycon.jp 
 
 お問い合わせ
 ============
+各イベントへのお問い合わせは、各イベント別のお問い合わせ窓口までお願いします。
+
 一般社団法人 PyCon JP へのお問い合せは、理事メールアドレス(board@pycon.jp)までお願いします。
 
 PyCon JP カレンダー

--- a/source/organizer/index.rst
+++ b/source/organizer/index.rst
@@ -184,14 +184,10 @@ PyCon JP 2018
 :Venue:
   - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_ (Tutorials, Conference)
   - `HDE <https://www.hde.co.jp/>`_ (Development Sprints)
+:Keynote:
+  - `Argentina in Python: community, dreams, travels and learning <https://www.slideshare.net/ManuelKaufmann/argentina-in-python-community-dreams-travels-and-learning>`_ / Kaufmann Manuel : `Video <https://www.youtube.com/watch?v=KwmF5wyY2C4>`_ 
+  - `「Pythonでやってみた」：広がるプログラミングの愉しみ <https://www.slideshare.net/RansuiIso/python-115121978>`_ / 磯 蘭水 : `Video <https://www.youtube.com/watch?v=kO4FNg648qE>`_ 
 :Attendees: 1,156(Sprint:60, Tutorial:111, Conference:985)
+:Description: 7 Tracks, 56 Talk sessins, 1 Invited talks, 4 Tutorials, Poster sessions, Jobs Fair and etc.
+:Sponsor: 1 Diamond, 2 Platinum, 7 Gold, 1 Sprint, 33 Silver, 14 Patrons, 6 Media , 3 Network Sponsor
 
-PyCon JP 2019
--------------
-
-:Date:
-  - Development Sprints: It is under consideration
-  - Tutorial: It is under consideration 
-  - Conference: 2019 Sep 16(Mon), 17(Tue)
-:Venue:
-  - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_ (Conference)

--- a/source/organizer/index.rst
+++ b/source/organizer/index.rst
@@ -15,7 +15,7 @@ PyCon JP は日本で開催される、プログラミング言語 Python に関
 Python はオープンソースで開発されているプログラミング言語で、世界中で利用されています。
 
 PyCon(Python Conference)は世界中で開催されており、2012年は2,000名以上が参加する PyCon US をはじめ、世界30箇所以上で開催されています。
-PyCon JP は2011年から毎年開催しており、PyCon JP 2016では約720名の参加者を集めアメリカ、ヨーロッパに次ぐ世界最大規模のカンファレンスとなっています。
+PyCon JP は2011年から毎年開催しており、PyCon JP 2018では約1000名の参加者を集めアメリカ、ヨーロッパに次ぐ世界最大規模のカンファレンスとなっています。
 
 過去の PyCon JP
 ===============
@@ -146,7 +146,7 @@ PyCon JP 2016
 :Venue:
   - `Waseda University, Nishi-Waseda Campus <https://www.waseda.jp/top/access/nishiwaseda-campus>`_ (Tutorials, Conference)
   - `Microsoft Japan <https://www.microsoft.com/>`_ (Development Sprints)
-:Attendees: 720
+:Attendees: 720(Conference)
 :Keynote:
   - Jessica McKellar
   - `What's new in Python 3.6 <http://blog.pirx.ru/media/files/2016/vlasovskikh-whats-new-in-python36.pdf>`_ / Andrey Vlasovskikh
@@ -165,7 +165,7 @@ PyCon JP 2017
 :Venue:
   - `Waseda University, Nishi-Waseda Campus <https://www.waseda.jp/top/access/nishiwaseda-campus>`_ (Tutorials, Conference)
   - `Microsoft Japan <https://www.microsoft.com/>`_ (Development Sprints)
-:Attendees: 691
+:Attendees: 691(Conference)
 :Keynote:
   - `Python for Data: Past, Present, Future <http://www.slideshare.net/misterwang/python-for-data-past-present-future-pycon-jp-2017-keynote>`_ / Peter Wang
   - `pandasでのOSS活動 事例と最初の一歩 <https://speakerdeck.com/sinhrks/pandasdefalseosshuo-dong-shi-li-tozui-chu-false-bu>`_ / 堀越 真映 
@@ -184,4 +184,14 @@ PyCon JP 2018
 :Venue:
   - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_ (Tutorials, Conference)
   - `HDE <https://www.hde.co.jp/>`_ (Development Sprints)
-:Attendees: 1,000(planned)
+:Attendees: 1,156(Sprint:60, Tutorial:111, Conference:985)
+
+PyCon JP 2019
+-------------
+
+:Date:
+  - Development Sprints: It is under consideration
+  - Tutorial: It is under consideration 
+  - Conference: 2019 Sep 16(Mon), 17(Tue)
+:Venue:
+  - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_ (Conference)


### PR DESCRIPTION
下記のUpdate

PyCon JP 2018開催終了
PyCon JP 2019開催の案内
イベント問い合わせ先についての記載
