### PR TITLE
update PyCon JP 2019 history

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -21,47 +21,19 @@ PyCon JPに関する最新情報は以下のBlog, Twitter, Facebookを参照し�
 :Twitter: `@PyConJ <https://twitter.com/pyconj>`_
 :Facebook: `PyConJP <http://www.facebook.com/PyConJP>`_
 
-
 PyCon JP 2019
 =============
 .. image:: /_static/pyconjp2019-logo.png
    :alt: PyCon JP 2019 logo
 
-今年もPyConJP2019を開催いたします。 `チケット販売 <https://pyconjp.connpass.com/event/135734/>`_ を開始しました！
+PyConJP2019を開催終了しました。
 
-下記は開催概要です。
-詳細については `公式Webサイト <https://pycon.jp/2019>`_ を確認ください。
+詳細については `公式Webサイト <https://pycon.jp/2019>`_ をご確認ください。
 
-Here is a summary of the event details. We'll post updates as further details are confirmed.
-
-.. list-table::
-   :widths: 30 70
-   :stub-columns: 1
-
-   * - Development Sprints
-     - 2019-9-14(Sat)
-   * - Development Sprints Venue / 会場
-     - `HENNGE K.K. Tokyo Office, Shibuya <https://hennge.com/jp/about/map/>`_
-   * - Tutorial
-     -  2019-9-15(Sun)
-   * - Tutorial Venue / 会場
-     - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_
-   * - Conference(2 days)
-     - 2019-9-16(Mon, public holiday), 2019-9-17(Tue)
-   * - Conference Venue / 会場
-     - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_          
-   * - Organizers / 運営
-     - PyCon JP 2019 Organizing Committee
-          
 お問い合わせ
 ============
-PyCon JP 2019 スピーカーの方はCFP応募したpapercallのfeedbackからお問い合わせください。
 
-PyCon JP 2019 スポンサーの方は `【スポンサー向け】イベントスケジュールおよびFAQ  <https://docs.google.com/document/d/1d_Gq3-8VldxO3dN0ApebLbx1OHkTUaLjfkpic0SKx7Y/edit#>`_ をご確認の上、slackからお問い合わせください。
-
-PyCon JP 2019 一般参加の方（含む一般の遠方支援申し込み者）は各connpass記載のメールアドレスにお問い合わせください。
-
-その他、各イベントへのお問い合わせは、各イベント別のお問い合わせ窓口までお願いします。
+各イベントへのお問い合わせは、各イベント別のお問い合わせ窓口までお願いします。
 
 一般社団法人 PyCon JP へのお問い合せは、理事メールアドレス(board@pycon.jp)までお願いします。
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -26,7 +26,7 @@ PyCon JP 2019
 .. image:: /_static/pyconjp2019-logo.png
    :alt: PyCon JP 2019 logo
 
-PyConJP2019を開催終了しました。
+PyCon JP 2019を開催終了しました。
 
 詳細については `公式Webサイト <https://pycon.jp/2019>`_ をご確認ください。
 

--- a/source/organizer/index.rst
+++ b/source/organizer/index.rst
@@ -171,7 +171,7 @@ PyCon JP 2017
 :Keynote:
   - `Python for Data: Past, Present, Future <http://www.slideshare.net/misterwang/python-for-data-past-present-future-pycon-jp-2017-keynote>`_ / Peter Wang
   - `pandasでのOSS活動 事例と最初の一歩 <https://speakerdeck.com/sinhrks/pandasdefalseosshuo-dong-shi-li-tozui-chu-false-bu>`_ / 堀越 真映 
-:Description: 3 Tracks, 40 Talk sessins, 1 Invited talks, 4 Tutorials, Poster sessions, Jobs Fair, Media Meeting and etc.
+:Description: 3 Tracks, 40 Talk sessions, 1 Invited talks, 4 Tutorials, Poster sessions, Jobs Fair, Media Meeting and etc.
 :Sponsor: 1 Diamond, 3 Platinum, 8 Gold, 28 Silver, 20 Patrons, 6 Media
 
 PyCon JP 2018
@@ -190,7 +190,7 @@ PyCon JP 2018
   - `Argentina in Python: community, dreams, travels and learning <https://www.slideshare.net/ManuelKaufmann/argentina-in-python-community-dreams-travels-and-learning>`_ / Kaufmann Manuel : `Video <https://www.youtube.com/watch?v=KwmF5wyY2C4>`__
   - `「Pythonでやってみた」：広がるプログラミングの愉しみ <https://www.slideshare.net/RansuiIso/python-115121978>`_ / 磯 蘭水 : `Video <https://www.youtube.com/watch?v=kO4FNg648qE>`__
 :Attendees: 1,156(Sprint:60, Tutorial:111, Conference:985)
-:Description: 7 Tracks, 56 Talk sessins, 1 Invited talks, 4 Tutorials, Poster sessions, Jobs Fair and etc.
+:Description: 7 Tracks, 56 Talk sessions, 1 Invited talks, 4 Tutorials, Poster sessions, Jobs Fair and etc.
 :Sponsor: 1 Diamond, 2 Platinum, 7 Gold, 1 Sprint, 33 Silver, 14 Patrons, 6 Media , 3 Network Sponsor
 
 PyCon JP 2019
@@ -209,6 +209,6 @@ PyCon JP 2019
   - `Why Python is Eating the World <https://speakerdeck.com/pyconjp/why-python-is-eating-the-world>`_ / Cory Althoff : `Video <https://www.youtube.com/watch?v=Bcxz-jXMLZk>`__
   - `Pythonで切り開く新しい農業 <https://www.slideshare.net/ikemkt/pyconjp2019python>`_ / 小池 誠 : `Video <https://www.youtube.com/watch?v=0bTPOsVvG7g>`__
 :Attendees: 1,160(Sprint:103, Tutorial:106, Conference:951)
-:Description: 5 Tracks, 47 Talk sessins, 1 Invited talks, 3 Tutorials, Poster sessions, Beginner session, Jobs Fair and etc.
+:Description: 5 Tracks, 47 Talk sessions, 1 Invited talks, 3 Tutorials, Poster sessions, Beginner session, Jobs Fair and etc.
 :Sponsor: 1 Diamond, 3 Platinum, 15 Gold, 1 Sprint, 21 Silver, 12 Patrons, 6 Media , 2 Network Sponsor
 

--- a/source/organizer/index.rst
+++ b/source/organizer/index.rst
@@ -38,6 +38,8 @@ PyCon JP は2011年から毎年開催しており、PyCon JP 2018では約1000�
   : 2017 Sep 7-9(Tutorial, Conference, Development Sprints)
 - `PyCon JP 2018 <https://pycon.jp/2018>`_
   : 2018 Sep 15-18(Tutorial, Conference, Development Sprints)
+- `PyCon JP 2019 <https://pycon.jp/2019>`_
+  : 2019 Sep 14-17(Tutorial, Conference, Development Sprints)
 
 過去の PyCon JP 詳細
 ====================
@@ -190,4 +192,23 @@ PyCon JP 2018
 :Attendees: 1,156(Sprint:60, Tutorial:111, Conference:985)
 :Description: 7 Tracks, 56 Talk sessins, 1 Invited talks, 4 Tutorials, Poster sessions, Jobs Fair and etc.
 :Sponsor: 1 Diamond, 2 Platinum, 7 Gold, 1 Sprint, 33 Silver, 14 Patrons, 6 Media , 3 Network Sponsor
+
+PyCon JP 2019
+-------------
+
+:URL: https://pycon.jp/2019/
+:Theme: Python New Era
+:Date:
+  - Development Sprints: 2019 Sep 14(Sat)
+  - Tutorial: 2019 Sep 15(Sun)
+  - Conference: 2019 Sep 16(Mon), 17(Tue)
+:Venue:
+  - `Ota City Industrial Plaza <https://www.pio-ota.net/about_pio/>`_ (Tutorials, Conference)
+  - `HENNGE <https://hennge.com/>`_ (Development Sprints)
+:Keynote:
+  - `Why Python is Eating the World <https://speakerdeck.com/pyconjp/why-python-is-eating-the-world>`_ / Cory Althoff : `Video <https://www.youtube.com/watch?v=Bcxz-jXMLZk>`__
+  - `Pythonで切り開く新しい農業 <https://www.slideshare.net/ikemkt/pyconjp2019python>`_ / 小池 誠 : `Video <https://www.youtube.com/watch?v=0bTPOsVvG7g>`__
+:Attendees: 1,160(Sprint:103, Tutorial:106, Conference:951)
+:Description: 5 Tracks, 48 Talk sessins, 1 Invited talks, 3 Tutorials, Poster sessions, Jobs Fair and etc.
+:Sponsor: 1 Diamond, 3 Platinum, 15 Gold, 1 Sprint, 21 Silver, 12 Patrons, 6 Media , 2 Network Sponsor
 

--- a/source/organizer/index.rst
+++ b/source/organizer/index.rst
@@ -209,6 +209,6 @@ PyCon JP 2019
   - `Why Python is Eating the World <https://speakerdeck.com/pyconjp/why-python-is-eating-the-world>`_ / Cory Althoff : `Video <https://www.youtube.com/watch?v=Bcxz-jXMLZk>`__
   - `Pythonで切り開く新しい農業 <https://www.slideshare.net/ikemkt/pyconjp2019python>`_ / 小池 誠 : `Video <https://www.youtube.com/watch?v=0bTPOsVvG7g>`__
 :Attendees: 1,160(Sprint:103, Tutorial:106, Conference:951)
-:Description: 5 Tracks, 48 Talk sessins, 1 Invited talks, 3 Tutorials, Poster sessions, Jobs Fair and etc.
+:Description: 5 Tracks, 47 Talk sessins, 1 Invited talks, 3 Tutorials, Poster sessions, Beginner session, Jobs Fair and etc.
 :Sponsor: 1 Diamond, 3 Platinum, 15 Gold, 1 Sprint, 21 Silver, 12 Patrons, 6 Media , 2 Network Sponsor
 

--- a/source/sponsor/sponsor.rst
+++ b/source/sponsor/sponsor.rst
@@ -2,8 +2,12 @@
  PyCon JP スポンサー情報
 =========================
 
-`2019 <https://drive.google.com/open?id=19fBidrOtpelYVyNUpkDiN7XZuHImOp1q_OyviOcg-yo>`_
+PyCon JP 2019
+=============
+募集終了しています。
 
-スポンサーに関するお問い合わせ
-------------------------------
-:連絡先: sponsor[ at ]pycon.jp
+`PyCon JP 2019 スポンサー募集要項 <https://drive.google.com/open?id=19fBidrOtpelYVyNUpkDiN7XZuHImOp1q_OyviOcg-yo>`_
+
+.. スポンサーに関するお問い合わせ
+.. ------------------------------
+.. :連絡先: sponsor[ at ]pycon.jp


### PR DESCRIPTION
2019を開催終了表記に変更、開催記録を記載。