### PR TITLE
Updated and added information about PyCon JP 2020 [ISSHA-2172].

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -23,26 +23,14 @@ PyCon JPに関する最新情報は以下のBlog, Twitter, Facebookを参照し�
 
 PyCon JP 2020
 =============
-PyCon JP 2020 conference will be held on August 28 and 29, 2020 at `online <https://pyconjp.blogspot.com/2020/04/notice-of-online-conference.html>`_ .
+PyCon JP 2020 ended successfully.
 
-We are currently considering whether to hold tutorials and sprints and their schedule.
+PyCon JP 2020は開催を終了しました。
 
-For the latest information for PyCon JP 2020, please visit `our Website <https://pycon.jp/2020/>`_ and `our blog <https://pyconjp.blogspot.com/search/label/pyconjp2020>`_ .
-
-PyCon JP 2020は、2020年8月28日、29日に `オンライン <https://pyconjp.blogspot.com/2020/04/notice-of-online-conference.html>`_ にてカンファレンスを開催予定です。
-
-チュートリアル、スプリントの開催有無および日程については検討中です。
-
-詳細については `公式Webサイト <https://pycon.jp/2020/>`_ および `Blog <https://pyconjp.blogspot.com/search/label/pyconjp2020>`_ をご確認ください。
+`PyCon JP 2020 Website <https://pycon.jp/2020/>`_
 
 お問い合わせ
 ============
-PyCon JP 2020 スポンサーの方は `PyCon JP 2020 Online Sponsorship Package <https://drive.google.com/file/d/1IZjr8o-oWnFGq-O9-rSDYW0FCJNuyRgY/view>`_ をご確認の上、記載のメールアドレスにお問い合わせください。
-
-PyCon JP 2020 プロポーザルに関しての質問は `PyCon JP 2020 proposal question form <https://docs.google.com/forms/d/e/1FAIpQLScW-s8M96jsr9A7Fbu-GsDuBvrL5yu0QGr5gpZ20DmAtRzTqg/viewform>`_ からご連絡ください。
-
-PyCon JP 2020 一般参加希望の方は募集開始までお待ちください。
-
 各イベントへのお問い合わせは、各イベント別のお問い合わせ窓口までお願いします。
 
 一般社団法人PyCon JP Associationへのお問い合わせは、理事メールアドレス(board@pycon.jp)までお願いします。

--- a/source/organizer/index.rst
+++ b/source/organizer/index.rst
@@ -40,6 +40,8 @@ PyCon JP は2011年から毎年開催しており、PyCon JP 2018では約1000�
   : 2018 Sep 15-18(Tutorial, Conference, Development Sprints)
 - `PyCon JP 2019 <https://pycon.jp/2019>`_
   : 2019 Sep 14-17(Tutorial, Conference, Development Sprints)
+- `PyCon JP 2020 <https://pycon.jp/2020>`_
+  : 2020 Aug 28-29(Conference), Aug 22-30(Tutorial, Development Sprints)
 
 過去の PyCon JP 詳細
 ====================
@@ -118,7 +120,7 @@ PyCon JP 2014
   - `Rediscover with Python <http://www.slideshare.net/nishio/pyconjp-keynote-speach-japanese-version>`_ / 西尾 泰和
 :Description: 3トラック, 36セッション (英語1:日本語2), 3有料チュートリアル、ポスターセッション、ジョブフェア他
 :Sponsor: 1 Platinum, 6 Gold, 31 Silver, 41 Patrons, 6 Media
-          
+
 PyCon JP 2015
 -------------
 
@@ -170,7 +172,7 @@ PyCon JP 2017
 :Attendees: 691(Conference)
 :Keynote:
   - `Python for Data: Past, Present, Future <http://www.slideshare.net/misterwang/python-for-data-past-present-future-pycon-jp-2017-keynote>`_ / Peter Wang
-  - `pandasでのOSS活動 事例と最初の一歩 <https://speakerdeck.com/sinhrks/pandasdefalseosshuo-dong-shi-li-tozui-chu-false-bu>`_ / 堀越 真映 
+  - `pandasでのOSS活動 事例と最初の一歩 <https://speakerdeck.com/sinhrks/pandasdefalseosshuo-dong-shi-li-tozui-chu-false-bu>`_ / 堀越 真映
 :Description: 3 Tracks, 40 Talk sessions, 1 Invited talks, 4 Tutorials, Poster sessions, Jobs Fair, Media Meeting and etc.
 :Sponsor: 1 Diamond, 3 Platinum, 8 Gold, 28 Silver, 20 Patrons, 6 Media
 
@@ -212,3 +214,21 @@ PyCon JP 2019
 :Description: 5 Tracks, 47 Talk sessions, 1 Invited talks, 3 Tutorials, Poster sessions, Beginner session, Jobs Fair and etc.
 :Sponsor: 1 Diamond, 3 Platinum, 15 Gold, 1 Sprint, 21 Silver, 12 Patrons, 6 Media , 2 Network Sponsor
 
+PyCon JP 2020
+-------------
+
+:URL: https://pycon.jp/2020/
+:Date:
+  - Development Sprints: 2020 Aug 22(Sat) - 30(Sun)
+  - Conference: 2020 Aug 28(Fri), 29(Sat)
+  - Tutorial, Youth Coder Workshop: 2020 Aug 30(Sun)
+:Venue:
+  - Online(Zoom & YouTube Live)
+:Keynote:
+  - Pythonで遊ぼう コンピュータ将棋2020 / 芝世弐 : `Video <https://www.youtube.com/watch?v=ghVEuOuKW00>`__
+  - `From Serverless to Stateless <https://github.com/Miserlou/Talks/blob/master/pycon-jp-2020/talk.html>`_ / Rich Jones : `Video <https://www.youtube.com/watch?v=dNWRm21cVBI>`__
+:Attendees:
+  - Conference: 631(Zoom tickets) + 2,988(YouTube Live 2days Unique Users; an user accessing for 2 days is counted as 1 person)
+  - Tutorial: 40(Zoom tickets [sold out]) + 274(YouTube Live Unique Users)
+:Description(Conference): 5 Tracks(2 KeyNotes, 5 Invited talks, 49 Tals sessions), Lunch Time session, and etc.
+:Sponsor: 3 Platinum, 8 Gold, 8 Silver, 1 Special, 12 Patrons, 5 Tutorial, 6 Media


### PR DESCRIPTION
# 概要
-  PyCon JP 2020に関する情報を更新・追加しました。

## 対象JIRAチケット
- https://pyconjp.atlassian.net/browse/ISSHA-2172

## https://www.pycon.jp/
- PyCon JP 2020に関する情報を「開催終了」に更新しました。

## https://www.pycon.jp/organizer/index.html
- PyCon JP 2020の開催情報を追加しました。