### PR TITLE
トップページに2021のティザーサイトへのリンクを追加

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -28,11 +28,11 @@ PyCon JP 2021 のカンファレンス日程は2021/10/15-16に仮決定しま�
 
 私たちは一緒にイベントを創り上げるボランティアスタッフを大募集しています！是非ご協力ください！
 
-PyCon JP 2021 の最新情報およびお問い合わせは `PyCon JP Blog <https://pyconjp.blogspot.com/search/label/pyconjp2021>`_ をご確認ください。
+詳細については `公式Webサイト <https://2021.pycon.jp/>`_ および `PyCon JP Blog <https://pyconjp.blogspot.com/search/label/pyconjp2021>`_ をご確認ください。
 
 The schedule for PyCon JP 2021 has been tentatively set. Oct 15 to 16.
 
-Please check `PyCon JP Blog <https://pyconjp.blogspot.com/search/label/pyconjp2021>`_ for the latest information and questions about PyCon JP 2021.
+For the latest information for PyCon JP 2020, please visit `our Website <https://2021.pycon.jp/>`_ and `PyCon JP Blog <https://pyconjp.blogspot.com/search/label/pyconjp2021>`_ .
 
 お問い合わせ
 ============

--- a/source/index.rst
+++ b/source/index.rst
@@ -24,15 +24,15 @@ PyCon JPに関する最新情報は以下のBlog, Twitter, Facebookを参照し�
 
 PyCon JP 2021
 =============
-PyCon JP 2021 のカンファレンス日程は2021/10/15-16に仮決定しました!
+PyCon JP 2021 のカンファレンス日程は2021/10/15-16に決定しました!
 
 私たちは一緒にイベントを創り上げるボランティアスタッフを大募集しています！是非ご協力ください！
 
-詳細については `公式Webサイト <https://2021.pycon.jp/>`_ および `PyCon JP Blog <https://pyconjp.blogspot.com/search/label/pyconjp2021>`_ をご確認ください。
+PyCon JP 2021 の最新情報およびお問い合わせは `公式Webサイト <https://2021.pycon.jp/>`_ および `PyCon JP Blog <https://pyconjp.blogspot.com/search/label/pyconjp2021>`_ をご確認ください。
 
-The schedule for PyCon JP 2021 has been tentatively set. Oct 15 to 16.
+The schedule for PyCon JP 2021 has been set. Oct 15 to 16.
 
-For the latest information for PyCon JP 2020, please visit `our Website <https://2021.pycon.jp/>`_ and `PyCon JP Blog <https://pyconjp.blogspot.com/search/label/pyconjp2021>`_ .
+For the latest information or inquiries about PyCon JP 2021, please visit `our Website <https://2021.pycon.jp/>`_ and `PyCon JP Blog <https://pyconjp.blogspot.com/search/label/pyconjp2021>`_ .
 
 お問い合わせ
 ============


### PR DESCRIPTION
- トップページのPyCon JP 2021の項目に PyCon JP 2021ティザーサイトhttps://2021.pycon.jp へのリンクを追加