### PR TITLE
www.pycon.jp TOP を2024に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ $ python3.12 -m venv env
 $ . env/bin/activate
 (env)$ pip install -r requirements.txt
 (env)$ make html
-(env)$ open _build/html/index.html
+(env)$ open build/html/index.html
 ```

--- a/source/index.md
+++ b/source/index.md
@@ -21,24 +21,19 @@ PyCon JPに関する最新情報は以下のBlog, Twitter, Facebookを参照し�
 :Twitter: [@pyconjapan](https://twitter.com/pyconjapan)
 :Facebook: [PyConJP](http://www.facebook.com/PyConJP)
 
-## PyCon APAC 2023
+## PyCon JP 2024
 
-```{admonition} お知らせ
-[PyCon APAC 2023におけるNOCコンテンツに関するご指摘について](https://pyconjp.blogspot.com/2023/11/pyconapac2023-statement.html)
-```
-
-PyCon APAC 2023は2023年10月26日(木)-29日(日)に現地開催にて行われました。
-
-参加してくださったみなさん、多くのスポンサーさん、ボランティアスタッフのみなさんに感謝します。
-
-PyCon JP 2024の開催に関しては情報が決まり次第、公式ブログおよびTwitterなどでお知らせします。
-
-詳細は、下記公式サイトおよびブログをご覧ください。
-
-- [公式サイト](https://2023-apac.pycon.jp/)
-- [PyCon JP Blog(pyconapac2023 ラベル)](https://pyconjp.blogspot.com/search/label/pyconapac2023)
+PyCon JP 2024 のカンファレンス日程は2024/09/27-29に決定しました!  
+私たちは一緒にイベントを創り上げる主催メンバーを大募集しています！是非ご協力ください！
+PyCon JP 2024 の最新情報およびお問い合わせは [公式Webサイト](https://2024.pycon.jp/)および[PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2024)をご確認ください。
 
 過去のPyCon JP 開催情報は [こちら](https://www.pycon.jp/organizer/index.html) を参照ください。
+
+The schedule for PyCon JP 2024 has been set. Sep 27 to 29.  
+We are looking for organizing members to help us create the event together! We would love to have your help!
+For the latest information or inquiries about PyCon JP 2024, please visit [our Website](https://2024.pycon.jp/) and [PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2024).
+
+Please refer to [here](https://www.pycon.jp/organizer/index.html) for information on past PyCon JP events.
 
 ## お問い合わせ
 


### PR DESCRIPTION
- トップページの文言をPyCon JP 2024のものに変更しました。
  - 基本的に2021のものを踏襲しています。
- README.mdのコマンドを修正しました。
  - Makefileで定義されているビルド用のディレクトリ名が変わっていたので更新しました。