### PR TITLE
CoC問い合わせ先説明の修正

### DIFF
--- a/source/policies/code-of-conduct.md
+++ b/source/policies/code-of-conduct.md
@@ -68,7 +68,7 @@ PyCon JPの開催を通じて、Pythonの使い手が一堂に集まり、Python
 
 ## 問い合わせ先
 
-一般社団法人PyCon JP Associationが主催するイベントに関する、行動規範にの問い合わせ窓口
+一般社団法人PyCon JP Associationが主催するイベントに関する、行動規範の問い合わせ窓口
 
 [coc@pycon.jp](mailto:coc@pycon.jp)
 


### PR DESCRIPTION
https://www.pycon.jp/policies/code-of-conduct.html 問い合わせ先の説明を修正します。