### PR TITLE
Fix: double escape problem of MyST-Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 env/
 .vscode/
+**/__pycache__/

--- a/source/_ext/myst_patch.py
+++ b/source/_ext/myst_patch.py
@@ -1,0 +1,12 @@
+from myst_parser.mdit_to_docutils import base
+
+def setup(app):
+    # refs: https://github.com/executablebooks/MyST-Parser/issues/760
+    base.escapeHtml = lambda s: s
+
+    return {
+        'version': '0.1',
+        'env_version': 1,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/source/conf.py
+++ b/source/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 import sys
-# sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('_ext'))
 
 # -- Project information -----------------------------------------------------
 
@@ -28,6 +28,7 @@ author = 'PyCon JP Association'
 # ones.
 extensions = [
     "myst_parser",
+    "myst_patch",
     'sphinxext.opengraph',
 ]
 

--- a/source/policies/internet-policy.md
+++ b/source/policies/internet-policy.md
@@ -1,5 +1,4 @@
-[English translation of Internet connection service provision policy](https://bit.ly/3TsvXCx)
-<!-- Link to https://www-pycon-jp.translate.goog/policies/internet-policy.html?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=ja&_x_tr_pto=wapp -->
+[English translation of Internet connection service provision policy](https://www-pycon-jp.translate.goog/policies/internet-policy.html?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=ja&_x_tr_pto=wapp)
 
 # インターネット接続サービス提供ポリシー
 


### PR DESCRIPTION
fix for #107

MyST-Parser で & を含むURLを二重エスケープしてしまっている問題の修正。
