### PR TITLE
Add announcement for the end of PyCon JP 2024 and the upcoming PyCon JP 2025

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -47,6 +47,8 @@ PyCon JP 2024のカンファレンスは、2024年9月27日から29日に開催�
 
 PyCon JP 2024 へのお問い合わせは [公式Webサイト](https://2024.pycon.jp/)および[PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2024)をご確認ください。
 
+過去のPyCon JP 開催情報は [こちら](https://www.pycon.jp/organizer/index.html) を参照ください。
+
 The PyCon JP 2024 conference was held from September 27th to 29th, 2024!  
 Thanks to everyone who participated, our many sponsors, and all the volunteer staff, we successfully held the event.  
 We sincerely appreciate your support.

--- a/source/index.md
+++ b/source/index.md
@@ -22,17 +22,36 @@ PyCon JPに関する最新情報は以下のBlog, Twitter, Facebookを参照し�
 :Twitter: [@pyconjapan](https://twitter.com/pyconjapan)
 :Facebook: [PyConJP](http://www.facebook.com/PyConJP)
 
+## PyCon JP 2025
+
+PyCon JP 2025は、**2025年9月26日(金)から9月27日(土)** の2日間にわたり、広島国際会議場で開催されます！  
+今年も多くの参加者やスピーカー、スポンサーの皆さまをお迎えし、さまざまなセッションを予定しています。  
+
+詳細な情報や最新のアップデートは、[公式Webサイト](https://2025.pycon.jp/) および、[PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2025) をチェックしてください。今後、順次更新されていきますので、どうぞお楽しみに！
+
+皆さまのご参加を心よりお待ちしております。
+
+PyCon JP 2025 will be held over two days, from **Friday, September 26th to Saturday, September 27th, 2025** , at the Hiroshima International Conference Center!  
+We are excited to welcome many participants, speakers, and sponsors again this year, and we have a variety of sessions planned.  
+
+For detailed information and the latest updates, please check our [official website](https://2025.pycon.jp/) and [PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2025). We will be updating them regularly, so stay tuned!
+
+We look forward to your participation.
+
+
 ## PyCon JP 2024
 
-PyCon JP 2024 のカンファレンス日程は2024/09/27-29に決定しました!  
-私たちは一緒にイベントを創り上げる主催メンバーを大募集しています！是非ご協力ください！
-PyCon JP 2024 の最新情報およびお問い合わせは [公式Webサイト](https://2024.pycon.jp/)および[PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2024)をご確認ください。
+PyCon JP 2024のカンファレンスは、2024年9月27日から29日に開催されました！  
+ご参加いただいた皆さま、スポンサーの皆さま、そしてボランティアスタッフの皆さまのおかげで、無事に開催することができました。  
+心より感謝申し上げます。
 
-過去のPyCon JP 開催情報は [こちら](https://www.pycon.jp/organizer/index.html) を参照ください。
+PyCon JP 2024 へのお問い合わせは [公式Webサイト](https://2024.pycon.jp/)および[PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2024)をご確認ください。
 
-The schedule for PyCon JP 2024 has been set. Sep 27 to 29.  
-We are looking for organizing members to help us create the event together! We would love to have your help!
-For the latest information or inquiries about PyCon JP 2024, please visit [our Website](https://2024.pycon.jp/) and [PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2024).
+The PyCon JP 2024 conference was held from September 27th to 29th, 2024!  
+Thanks to everyone who participated, our many sponsors, and all the volunteer staff, we successfully held the event.  
+We sincerely appreciate your support.
+
+Inquiries about PyCon JP 2024, please visit [our Website](https://2024.pycon.jp/) and [PyCon JP Blog](https://pyconjp.blogspot.com/search/label/pyconjp2024).
 
 Please refer to [here](https://www.pycon.jp/organizer/index.html) for information on past PyCon JP events.
 

--- a/source/organizer/index.md
+++ b/source/organizer/index.md
@@ -298,5 +298,7 @@ PyCon JP は2011年から毎年開催しており、PyCon JP 2018では約1000�
   - Atsuo Ishimoto
 :Invited talk:
   - Naoki Inada
+:Attendee:
+  - Total: 651
 :Description(Conference): 4 Tracks(2 Keynotes, 1 Invited talk, 57 Talk sessions), Poster sessions, Lightning Talks and etc.
 :Sponsor: 3 Platinum, 28 Gold, 12 Silver, 6 Special, 14 Patrons


### PR DESCRIPTION
# 概要
- TOPページの2024の告知を終了のものに変更
- TOPページに2025の情報を追記
- PyCon JP イベント主催事業のページに2024の参加者数を追記