### PR TITLE
2024決算情報の数字修正（転記ミス）

### DIFF
--- a/source/annualreport/index.rst
+++ b/source/annualreport/index.rst
@@ -33,9 +33,9 @@
 
    - - PyCon JP 2024
      - 0円
-     - 3121万円
-     - 2542万円
-     - -793万円
+     - 3565万円
+     - 3203万円
+     - -363万円
      - `PyCon JP 2024会計報告 / PyCon JP 2024 Financial Report <https://pyconjp.blogspot.com/2024/11/2024-financial-report.html>`_
 
    - - Python Boot Camp
@@ -67,9 +67,9 @@
      - 2回実施
 
    - - PyLadies PyCamp TA参加
-     - 15万円
+     - 8万円
      - 0円
-     - 5万円
+     - 0万円
      - 0万円（0%）
      - 実施無し（予定合わず）
 


### PR DESCRIPTION
https://pyconjp.blogspot.com/2024/11/2024-financial-report.html を元に修正しました。

転記ミス、記載ミスですが、決算書自体には間違いはありません。このページに転記した表内だけ間違えてました